### PR TITLE
Update public repository with recent changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,8 @@ source 'https://rubygems.org'
 gemspec
 
 # custom fpm version from gemfury, see also: the thor comment below
-gem 'fpm', '~> 1.1.2'
+# The public version is compatible as well
+gem 'fpm', '~> 1.1'
 
 gem 'rake'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,7 +67,7 @@ GEM
       dotenv (~> 0.11.1)
       thor (~> 0.19.1)
     formatador (0.2.5)
-    fpm (1.1.2)
+    fpm (1.1.0)
       arr-pm (~> 0.0.9)
       backports (>= 2.6.2)
       cabin (>= 0.6.0)
@@ -157,7 +157,7 @@ PLATFORMS
 DEPENDENCIES
   ci_reporter (~> 1.9.0)
   fakefs
-  fpm (~> 1.1.2)
+  fpm (~> 1.1)
   guard-rspec (~> 4)
   pry (~> 0)
   pry-rescue (~> 1)

--- a/lib/slugforge/build/export_upstart.rb
+++ b/lib/slugforge/build/export_upstart.rb
@@ -4,7 +4,7 @@ module Slugforge
       desc :call, 'export upstart scripts from the Procfile'
       def call
         unless File.exist?(procfile_path)
-          logger.say_status :missing, 'foreman Procfile', :red
+          logger.say_status :missing, 'foreman Procfile', :yellow
           return false
         end
 

--- a/lib/slugforge/commands/deploy.rb
+++ b/lib/slugforge/commands/deploy.rb
@@ -45,7 +45,7 @@ module Slugforge
         logger.say_status :deploy, "deploying slug #{slug_name} from s3", :green
 
         url = expiring_url(slug)
-        deploy(hosts, slug_name, deploy_options(:copy_type => :aws_cmd, :url => url, :aws_session => aws_session, :s3_url => "s3://#{aws_bucket}/#{name_part}"))
+        deploy(hosts, slug_name, deploy_options(:copy_type => :aws_cmd, :url => url, :aws_session => aws_session, :s3_url => "s3://#{aws_bucket}/#{slug.key}"))
       end
 
       desc 'rollback <tag> <hosts...> [ARGS]', 'deploy the previous slug for a tag to host(s)'

--- a/lib/slugforge/commands/tag.rb
+++ b/lib/slugforge/commands/tag.rb
@@ -84,9 +84,10 @@ module Slugforge
           logger.say "Tags for #{project_name}"
           logger.say_status :'production-current', tag_manager.slug_for_tag(project_name, 'production-current') unless pc.nil?
 
-          tags.parallel_map do |tag|
+          tag_list = tags.parallel_map do |tag|
             [tag, tag_manager.slug_for_tag(project_name, tag)]
-          end.sort {|a,b| b[1]<=>a[1] }.each do |tag, slug|
+          end
+          tag_list.sort {|a,b| b[1].to_s<=>a[1].to_s }.each do |tag, slug|
             logger.say_status tag, slug, :yellow
           end
         end

--- a/lib/slugforge/configuration.rb
+++ b/lib/slugforge/configuration.rb
@@ -34,7 +34,7 @@ module Slugforge
 
     option :aws_access_key,    :key => 'aws.access_key',  :option => :'aws-access-key-id', :env => 'AWS_ACCESS_KEY_ID'
     option :aws_secret_key,    :key => 'aws.secret_key',  :option => :'aws-secret-key',    :env => 'AWS_SECRET_ACCESS_KEY'
-    option :ec2_region,        :key => 'ec2.region',      :option => :'ec2-region',        :env => 'EC2_REGION', :default => 'us-east-1'
+    option :aws_region,        :key => 'aws.region',      :option => :'aws-region',        :env => 'AWS_DEFAULT_REGION', :default => 'us-east-1'
     option :slug_bucket,       :key => 'aws.slug_bucket', :option => :'slug-bucket',       :env => 'SLUG_BUCKET'
     option :aws_session_token, :option => :'aws-session-token'
 
@@ -42,7 +42,7 @@ module Slugforge
 
     option :ssh_username, :key => 'ssh.username', :option => :'ssh-username', :env => 'SSH_USERNAME'
 
-    option :allow_slugins, :key => 'allow_slugins', :option => :'allow-slugins', :default => true
+    option :disable_slugins, :key => 'disable_slugins', :option => :'disable-slugins', :env => 'DISABLE_SLUGINS'
 
     attr_reader :values
 
@@ -60,7 +60,7 @@ module Slugforge
     end
 
     def activate_slugins
-      @slugin_manager.activate_slugins(self) if allow_slugins
+      @slugin_manager.activate_slugins(self) unless disable_slugins
     end
 
     protected
@@ -74,7 +74,7 @@ module Slugforge
 
       locate_slugins
       #TODO: disable individual slugins via configuration
-      load_slugins if allow_slugins
+      load_slugins unless disable_slugins
 
       load_configuration_files
       read_env

--- a/lib/slugforge/helper/build.rb
+++ b/lib/slugforge/helper/build.rb
@@ -3,7 +3,7 @@ module Slugforge
     module Build
       def verify_procfile_exists!
         unless File.exist?(project_path('Procfile'))
-          raise error_class, "Slugforge must be run in a project with a Procfile (#{project_path('Procfile')})"
+          logger.say_status :warning, "Slugforge should normally be run in a project with a Procfile (#{project_path('Procfile')})", :yellow
         end
       end
 

--- a/lib/slugforge/helper/config.rb
+++ b/lib/slugforge/helper/config.rb
@@ -6,8 +6,8 @@ module Slugforge
           :desc => 'The AWS Access ID to use for hosts and buckets, unless overridden'
         base.class_option :'aws-secret-key', :type => :string, :aliases => '-S', :group => :config,
           :desc => 'The AWS Secret Key to use for hosts and buckets, unless overridden'
-        base.class_option :'ec2-region', :type => :string, :group => :config,
-          :desc => 'The AWS region to use for EC2 instances'
+        base.class_option :'aws-region', :type => :string, :group => :config,
+          :desc => 'The AWS region to use for EC2 instances and buckets'
         base.class_option :'slug-bucket', :type => :string, :group => :config,
           :desc => 'The S3 bucket to store the slugs and tags in'
         base.class_option :'aws-session-token', :type => :string, :group => :config,
@@ -19,8 +19,8 @@ module Slugforge
         base.class_option :'ssh-username', :type => :string, :aliases => '-u', :group => :config,
           :desc => 'The account used to log in to the host (requires sudo privileges)'
 
-        base.class_option :'allow-slugins', :type => :boolean, :group => :config, :default => true,
-          :desc => 'Allow slugin loading'
+        base.class_option :'disable-slugins', :type => :boolean, :group => :config,
+          :desc => 'Disable slugin loading'
 
         base.class_option :verbose, :type => :boolean, :aliases => '-V', :group => :runtime,
           :desc => 'Display verbose output'

--- a/lib/slugforge/helper/fog.rb
+++ b/lib/slugforge/helper/fog.rb
@@ -5,7 +5,7 @@ module Slugforge
     module Fog
       def compute
         @compute ||= ::Fog::Compute.new(aws_credentials.merge({
-          :region   => config.ec2_region,
+          :region   => config.aws_region,
           :provider => 'AWS'
         }))
       end
@@ -49,7 +49,8 @@ module Slugforge
           {
             aws_access_key_id:     token.body['AccessKeyId'],
             aws_secret_access_key: token.body['SecretAccessKey'],
-            aws_session_token:     token.body['SessionToken']
+            aws_session_token:     token.body['SessionToken'],
+            aws_region:            config.aws_region
           }
         end
       end
@@ -75,7 +76,7 @@ module Slugforge
             },
             {
               "Action"   => [
-                 "s3:ListBucket"
+                "s3:ListBucket"
               ],
               "Effect"   => "Allow",
               "Resource" => [ "arn:aws:s3:::#{bucket}" ]

--- a/lib/slugforge/models/host.rb
+++ b/lib/slugforge/models/host.rb
@@ -165,7 +165,7 @@ module Slugforge
         @deploy_results << ssh_command(ssh, "sudo mv #{slug_name} #{slug_name_with_path}", logger)
       else # AWS S3 command line by default
         logger.log "copying slug to host via aws s3 command (#{name})", {:color => :green, :status => :copy, :log_level => :verbose}
-        @deploy_results << ssh_command(ssh, "sudo -- sh -c 'export AWS_ACCESS_KEY_ID=#{opts[:aws_session][:aws_access_key_id]}; export AWS_SECRET_ACCESS_KEY=#{opts[:aws_session][:aws_secret_access_key]}; export AWS_SECURITY_TOKEN=#{opts[:aws_session][:aws_session_token]}; aws s3 cp #{opts[:s3_url]} #{slug_name_with_path}'; echo \"SSH_COMMAND_EXIT_CODE=$?\"", logger)
+        @deploy_results << ssh_command(ssh, "sudo -- sh -c 'export AWS_ACCESS_KEY_ID=#{opts[:aws_session][:aws_access_key_id]}; export AWS_SECRET_ACCESS_KEY=#{opts[:aws_session][:aws_secret_access_key]}; export AWS_SECURITY_TOKEN=#{opts[:aws_session][:aws_session_token]}; export AWS_DEFAULT_REGION=#{opts[:aws_session][:aws_region]}; aws s3 cp #{opts[:s3_url]} #{slug_name_with_path}'; echo \"SSH_COMMAND_EXIT_CODE=$?\"", logger)
       end
       record_event :copied
       slug_name_with_path

--- a/lib/slugforge/models/tag_manager.rb
+++ b/lib/slugforge/models/tag_manager.rb
@@ -36,6 +36,9 @@ module Slugforge
       end
     end
 
+    # This method should be called before iterating over a large set of slugs and
+    # calling #tags_for_slug on them. By doing this you are able to query all the
+    # data from AWS in advance using parallelized threads, rather than in serial.
     def memoize_slugs_for_tags(project_name)
       @slugs_for_tag[project_name] ||= {}
       tag_map = tags(project_name).parallel_map do |tag|

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -24,12 +24,12 @@ mkdir -p ${SHARED_DIR}/config
 linked_dirs=(log pids tmp)
 
 for d in ${linked_dirs[@]} ; do
-    mkdir -p "${SHARED_DIR}/${d}"
-    # create the symlinks for shared folders, if needed
-    if [ ! -h "$INSTALL_DIR/${d}" ] ; then
-        rm -rf "$INSTALL_DIR/${d}" # delete local copy, use shared
-        ln -s -f "${SHARED_DIR}/${d}" "${INSTALL_DIR}/${d}"
-    fi
+  mkdir -p "${SHARED_DIR}/${d}"
+  # create the symlinks for shared folders, if needed
+  if [ ! -h "$INSTALL_DIR/${d}" ] ; then
+    rm -rf "$INSTALL_DIR/${d}" # delete local copy, use shared
+    ln -s -f "${SHARED_DIR}/${d}" "${INSTALL_DIR}/${d}"
+  fi
 done
 chmod -R 775 ${SHARED_DIR}
 
@@ -37,98 +37,107 @@ chmod -R 775 ${SHARED_DIR}
 chown -R $OWNER ${INSTALL_ROOT}
 
 # make sure all deploy scripts are executable
-chmod +x ${INSTALL_DIR}/deploy/*
+if [ -e "${INSTALL_DIR}/deploy/*" ] ; then
+  chmod +x ${INSTALL_DIR}/deploy/*
+fi
 
 # if environment file exists, link it into current directory so DotEnv and foreman run work
 if [ -r "${SHARED_DIR}/env" ] ; then
-    ln -s -f "${SHARED_DIR}/env" "${INSTALL_DIR}/.env"
+  ln -s -f "${SHARED_DIR}/env" "${INSTALL_DIR}/.env"
 fi
 
 # run post_install script, if present
 if [ -r "${INSTALL_DIR}/deploy/post_install" ] ; then
-    echo "Running post_install script..."
-    su - $OWNER -c "${INSTALL_DIR}/deploy/post_install"
+  echo "Running post_install script..."
+  # change into INSTALL_DIR so that folks can use pwd to get package install location
+  su - $OWNER -c "cd ${INSTALL_DIR}; deploy/post_install"
 fi
 
 if which service && which start && which stop > /dev/null 2>&1 ; then
-    UPSTART_PRESENT=true
+  UPSTART_PRESENT=true
 else
-    UPSTART_PRESENT=false
+  UPSTART_PRESENT=false
 fi
 
 if $UPSTART_PRESENT ; then
-    if [ -n "$CONCURRENCY" ] ; then
-        CONCURRENCY="-c $CONCURRENCY"
+  if [ -n "$CONCURRENCY" ] ; then
+    CONCURRENCY="-c $CONCURRENCY"
 
-	# split up the concurrency string into its parts and check each app to see if its
-	# unicorn or rainbows. We can only have one at a time because if they share a pid
-	# directory unicorn-upstart can't tell which process to watch.
-	# e.g.
-	# web=1,other=1 gets split on the command then app gets split on the = to be web and other
-	FOUND_UNICORN=false
-	for app in $(echo ${CONCURRENCY/,/ }) ; do
-	    app=${app%=*}
-	    if egrep -q "^${app}:.*(unicorn|rainbows)" "${INSTALL_DIR}/Procfile" ; then
-		if $FOUND_UNICORN ; then
-		    echo "The concurrency you have set of '$CONCURRENCY' will result in two unicorn or rainbows servers running at the same time. Slug deploys do not support that."
-		    echo "Update your concurrency to only run one. You can deploy also this slug again in another directory with a different concurrency to run both simultaneously."
-		    exit 1
-		fi
-		FOUND_UNICORN=true
-	    fi
-	done
-    fi
+    # split up the concurrency string into its parts and check each app to see if its
+    # unicorn or rainbows. We can only have one at a time because if they share a pid
+    # directory unicorn-upstart can't tell which process to watch.
+    # e.g.
+    # web=1,other=1 gets split on the command then app gets split on the = to be web and other
+    FOUND_UNICORN=false
+    for app in $(echo ${CONCURRENCY/,/ }) ; do
+      app=${app%=*}
+      if egrep -q "^${app}:.*(unicorn|rainbows)" "${INSTALL_DIR}/Procfile" ; then
+        if $FOUND_UNICORN ; then
+          echo "The concurrency you have set of '$CONCURRENCY' will result in two unicorn or rainbows servers running at the same time. Slug deploys do not support that."
+          echo "Update your concurrency to only run one. You can deploy also this slug again in another directory with a different concurrency to run both simultaneously."
+          exit 1
+        fi
+        FOUND_UNICORN=true
+      fi
+    done
+  fi
 
-    PROJECT_NAME=$(basename $INSTALL_ROOT)
+  PROJECT_NAME=$(basename $INSTALL_ROOT)
 
-    # upstart has problems with services with dashes in them
-    PROJECT_NAME=${PROJECT_NAME/-/_}
+  # upstart has problems with services with dashes in them
+  PROJECT_NAME=${PROJECT_NAME/-/_}
 
-    if [ -n "$RUNTIME_RUBY_VERSION" ] ; then
-        # used inside the foreman template
-        export RUBY_CMD="rvm use $RUNTIME_RUBY_VERSION do"
-    elif [ -r "${INSTALL_DIR}/.ruby-version" ] ; then
-        export RUBY_CMD="rvm use $(head -n 1 ${INSTALL_DIR}/.ruby-version) do"
-    fi
+  if [ -n "$RUNTIME_RUBY_VERSION" ] ; then
+    # used inside the foreman template
+    export RUBY_CMD="rvm use $RUNTIME_RUBY_VERSION do"
+  elif [ -r "${INSTALL_DIR}/.ruby-version" ] ; then
+    export RUBY_CMD="rvm use $(head -n 1 ${INSTALL_DIR}/.ruby-version) do"
+  fi
 
+  # check for a Procfile that is not zero size
+  if [ -s "$INSTALL_DIR/Procfile" ] ; then
+    # run foreman export to export the upstart scripts
     EXPORT_COMMAND="foreman export upstart /etc/init -a $PROJECT_NAME -f $INSTALL_DIR/Procfile -l $INSTALL_DIR/log $CONCURRENCY -t $INSTALL_DIR/deploy/upstart-templates -d $INSTALL_ROOT -u $OWNER"
     echo "Running foreman export command '$EXPORT_COMMAND'"
     $EXPORT_COMMAND
 
     # start or restart the service
     if status ${PROJECT_NAME} | grep -q running ; then
-        # restart the service
-        echo "Post install complete. Restarting ${PROJECT_NAME} service... "
-        restart ${PROJECT_NAME}
+      # restart the service
+      echo "Post install complete. Restarting ${PROJECT_NAME} service... "
+      restart ${PROJECT_NAME}
     else
-        # start the new service
-        echo "Post install complete. Starting ${PROJECT_NAME} service... "
-        start ${PROJECT_NAME}
+      # start the new service
+      echo "Post install complete. Starting ${PROJECT_NAME} service... "
+      start ${PROJECT_NAME}
     fi
+  else
+    echo "Procfile is missing or zero size. *NOT* running foreman export command."
+  fi
 else
-    echo "This machine does not appear to have upstart installed so we're skipping"
-    echo "exporting the upstart service config files."
+  echo "This machine does not appear to have upstart installed so we're skipping"
+  echo "exporting the upstart service config files."
 fi
 
 if [ -d "/etc/logrotate.d" ] ; then
-    LOGROTATE_FILE="/etc/logrotate.d/${PROJECT_NAME}"
-    LOG_DIR="${INSTALL_DIR}/log"
-    echo "Installing logrotate config ${LOGROTATE_FILE}"
-    : ${LOGROTATE_POSTROTATE:="restart ${PROJECT_NAME}"}
-    cat <<EOF > "${LOGROTATE_FILE}"
+  LOGROTATE_FILE="/etc/logrotate.d/${PROJECT_NAME}"
+  LOG_DIR="${INSTALL_DIR}/log"
+  echo "Installing logrotate config ${LOGROTATE_FILE}"
+  : ${LOGROTATE_POSTROTATE:="restart ${PROJECT_NAME}"}
+  cat <<EOF > "${LOGROTATE_FILE}"
 ${LOG_DIR}/*log ${LOG_DIR}/*/*.log {
-    size=10G
-    rotate 2
-    missingok
-    notifempty
-    sharedscripts
-    postrotate
-        ${LOGROTATE_POSTROTATE}
-    endscript
+  size=10G
+  rotate 2
+  missingok
+  notifempty
+  sharedscripts
+  postrotate
+    ${LOGROTATE_POSTROTATE}
+  endscript
 }
 
 EOF
 else
-    echo "This machine does not appear to have logrotate installed so we're skipping"
-    echo "log rotation config."
+  echo "This machine does not appear to have logrotate installed so we're skipping"
+  echo "log rotation config."
 fi

--- a/spec/slugforge/commands/deploy_spec.rb
+++ b/spec/slugforge/commands/deploy_spec.rb
@@ -13,6 +13,7 @@ describe Slugforge::Commands::Deploy, :config => true do
     let(:stderr)    { StringIO.new }
     let(:output)    { capture(:stdout, stdout) { capture(:stderr, stderr) { Slugforge::Cli.start(cmd) } } }
     let(:result)    { JSON.parse(output) }
+    let(:s3_root)   { "s3://#{helpers.config.values[:slug_bucket]}/#{project}" }
 
     shared_examples_for "a deployment method" do
       it "should succeed" do
@@ -22,11 +23,17 @@ describe Slugforge::Commands::Deploy, :config => true do
           fail stderr.string
         end
       end
+
+      it "has a full slug path" do
+        Slugforge::Commands::Deploy.any_instance.should_receive(:deploy).with(anything, anything, hash_including(locator))
+        output
+      end
     end
 
     describe "#file" do
       let(:operation) { "file" }
       let(:target)    { "artifact.slug" }
+      let(:locator)   { {:filename => target} }
 
       it_should_behave_like "a deployment method"
     end
@@ -34,12 +41,13 @@ describe Slugforge::Commands::Deploy, :config => true do
     describe "#tag" do
       let(:operation) { "tag" }
       let(:target)    { "testing" }
+      let(:slug_name) { "123.slug" }
+      let(:locator)   { {:s3_url => "#{s3_root}/#{slug_name}"} }
 
       context "with existing tagged slug" do
         before(:each) do
-          slug = "123.slug"
-          create_slug project, slug
-          create_tag project, target, slug
+          create_slug project, slug_name
+          create_tag project, target, slug_name
         end
 
         it_should_behave_like "a deployment method"
@@ -49,10 +57,11 @@ describe Slugforge::Commands::Deploy, :config => true do
     describe "#name" do
       let(:operation) { "name" }
       let(:target)    { "123456" }
+      let(:locator)   { {:s3_url => "#{s3_root}/#{target}.slug"} }
 
       context "with existing named slug" do
         before(:each) do
-          create_slug project, "#{target}.slug"
+          create_slug project, "#{target}"
         end
 
         it_should_behave_like "a deployment method"

--- a/spec/slugforge/helper/fog_spec.rb
+++ b/spec/slugforge/helper/fog_spec.rb
@@ -11,7 +11,7 @@ describe Slugforge::Helper::Fog, :config => false do
     end
   end
 
-  let(:options) {{ 'aws-access-key-id' => 'abc', 'aws-secret-key' => '123', 'slug-bucket' => 'bucket' }}
+  let(:options) {{ 'aws-access-key-id' => 'abc', 'aws-region' => 'north-pole-9', 'aws-secret-key' => '123', 'slug-bucket' => 'bucket' }}
 
   let(:command) { command_class.new [], options }
 
@@ -72,6 +72,7 @@ describe Slugforge::Helper::Fog, :config => false do
     it "should return a session hash matching what fog expects for credentials" do
       expect(command.aws_session).to eq({
         :aws_access_key_id     => session['AccessKeyId'],
+        :aws_region            => options['aws-region'],
         :aws_secret_access_key => session['SecretAccessKey'],
         :aws_session_token     => session['SessionToken']
       })

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -5,12 +5,13 @@ end
 
 def create_tag(project, tag, slug)
   bucket = helpers.s3.directories.new(:key => 'tj-slugforge')
-  bucket.files.create :key => "#{project}/tags/#{tag}", :body => slug
+  bucket.files.create :key => "#{project}/tags/#{tag}", :body => "#{project}/#{slug}"
 end
 
 def build_sts_response
   double('STS Response', :body => {
     'AccessKeyId' => "access-#{rand(1000)}",
+    'AwsRegion' => "region-#{rand(1000)}",
     'SecretAccessKey' => "secret-#{rand(1000)}",
     'SessionToken' => "session-#{rand(1000)}"
     })


### PR DESCRIPTION
This update includes the recent changes made to Slugforge:
- Support for packing repositories that do not have a Procfile
- A bug fix for `slugforge deploy name`
- Pass AWS_DEFAULT_REGION through to deployment commands
- Deploys are now a no-op when deploying a slug to a box where that slug is already symlinked to `current`

@Tapjoy/opsautomation 
