### PR TITLE
aws_tag_group should allow ":" as in "user:facet_name=5rocks..."

### DIFF
--- a/lib/slugforge/models/host_group/aws_tag_group.rb
+++ b/lib/slugforge/models/host_group/aws_tag_group.rb
@@ -5,7 +5,7 @@ module Slugforge
 
   class AwsTagGroup < HostGroup
     def self.matcher
-      /^(\w+)=(\S+)$/
+      /^([\w:]+)=(\S+)$/
     end
 
     def initialize(pattern, compute)


### PR DESCRIPTION
5rocks_server-app uses "user:facet_name" tag and slugforge needs to allow this pattern.
@jjrussell am I doing this right?
